### PR TITLE
[cmake] Download NuGet instead of using from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ A [Flutter](https://flutter.dev/) WebView plugin for Windows built on [Microsoft
 ### Development platform requirements
 - Visual Studio 2019
 - Windows 10 SDK 1903+ (10.0.18362.1)
-- nuget.exe in your $PATH for installing the following dependencies:
-  - [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2/) (will be installed automatically)
-  - [Microsoft.Windows.ImplementationLibrary](https://www.nuget.org/packages/Microsoft.Windows.ImplementationLibrary/) (will be installed automatically)
 
 ## Demo
 ![image](https://user-images.githubusercontent.com/720469/116823636-d8b9fe00-ab85-11eb-9f91-b7bc819615ed.png)

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -20,16 +20,21 @@ set(PLUGIN_NAME "webview_windows_plugin")
 
 add_subdirectory(third_party/fmt)
 
-find_program(NUGET_EXE NAMES nuget)
-if(NOT NUGET_EXE)
-	message("NUGET.EXE not found.")
-	message(FATAL_ERROR "Please install this executable, and run CMake again.")
+set(NUGET_URL https://dist.nuget.org/win-x86-commandline/latest/nuget.exe)
+set(NUGET ${CMAKE_CURRENT_SOURCE_DIR}/nuget.exe)
+if (NOT EXISTS ${NUGET})
+  file(DOWNLOAD ${NUGET_URL} ${NUGET})
 endif()
 
-exec_program(${NUGET_EXE}
-    ARGS install "Microsoft.Web.WebView2" -Version ${WEBVIEW_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
-exec_program(${NUGET_EXE}
-    ARGS install "Microsoft.Windows.ImplementationLibrary" -Version ${WIL_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
+if (EXISTS ${NUGET})
+  add_custom_target(DEPENDENCIES_DOWNLOAD ALL)
+  add_custom_command(
+    TARGET DEPENDENCIES_DOWNLOAD PRE_BUILD
+    COMMAND ${NUGET} install Microsoft.Windows.ImplementationLibrary -Version ${WIL_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
+    COMMAND ${NUGET} install Microsoft.Web.WebView2 -Version ${WEBVIEW_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
+    DEPENDS ${NUGET}
+  )
+endif()
 
 add_library(${PLUGIN_NAME} SHARED
   "webview_windows_plugin.cc"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -20,13 +20,15 @@ set(PLUGIN_NAME "webview_windows_plugin")
 
 add_subdirectory(third_party/fmt)
 
-set(NUGET_URL https://dist.nuget.org/win-x86-commandline/latest/nuget.exe)
-set(NUGET ${CMAKE_CURRENT_SOURCE_DIR}/nuget.exe)
+set(NUGET_URL https://dist.nuget.org/win-x86-commandline/v5.10.0/nuget.exe)
+set(NUGET_SHA256 852b71cc8c8c2d40d09ea49d321ff56fd2397b9d6ea9f96e532530307bbbafd3)
+set(NUGET ${CMAKE_BINARY_DIR}/nuget.exe)
 if (NOT EXISTS ${NUGET})
   file(DOWNLOAD ${NUGET_URL} ${NUGET})
 endif()
 
-if (EXISTS ${NUGET})
+file(SHA256 ${NUGET} NUGET_DL_HASH)
+if (NUGET_DL_HASH STREQUAL NUGET_SHA256)
   add_custom_target(DEPENDENCIES_DOWNLOAD ALL)
   add_custom_command(
     TARGET DEPENDENCIES_DOWNLOAD PRE_BUILD
@@ -34,6 +36,8 @@ if (EXISTS ${NUGET})
     COMMAND ${NUGET} install Microsoft.Web.WebView2 -Version ${WEBVIEW_VERSION} -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
     DEPENDS ${NUGET}
   )
+else()
+  message(FATAL_ERROR "Integrity check for ${NUGET} failed")
 endif()
 
 add_library(${PLUGIN_NAME} SHARED


### PR DESCRIPTION
Just a little change, not really sure if an improvement. 
Since Android downloads whole more than hundred MB of Gradle for the first time, I don't think fetching 5 MB NuGet will annoy somebody.