### PR TITLE
Fix resize crash

### DIFF
--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -261,7 +261,7 @@ void Webview::RegisterEventHandlers() {
 void Webview::SetSurfaceSize(size_t width, size_t height) {
   auto surface = surface_.get();
 
-  if (surface) {
+  if (surface && width > 0 && height > 0) {
     surface.Size({(float)width, (float)height});
 
     RECT bounds;


### PR DESCRIPTION
Crashes when resizing all the way down to 0 then trying to increase it back out

There's a slight chance that it doesn't crash, I don't quite understand it, thought maybe its the surface sizes being odd integers for the first call to SetSurfaceSize after 0 is set