### PR TITLE
Add history controls

### DIFF
--- a/lib/webview_windows.dart
+++ b/lib/webview_windows.dart
@@ -27,8 +27,8 @@ enum WebviewPermissionKind {
 enum WebviewPermissionDecision { none, allow, deny }
 
 class HistoryChanged {
-  bool canGoBack;
-  bool canGoForward;
+  final bool canGoBack;
+  final bool canGoForward;
   HistoryChanged(this.canGoBack, this.canGoForward);
 }
 

--- a/lib/webview_windows.dart
+++ b/lib/webview_windows.dart
@@ -124,11 +124,11 @@ class WebviewController extends ValueNotifier<WebviewValue> {
   /// Throws [PlatformException] if the environment was initialized before.
   static Future<void> initializeEnvironment(
       {String? userDataPath, String? additionalArguments}) async {
-    await _pluginChannel.invokeMethod(
+    return _pluginChannel.invokeMethod(
         'initializeEnvironment', <String, dynamic>{
-      'userDataPath': userDataPath,
-      'additionalArguments': additionalArguments
-    });
+        'userDataPath': userDataPath,
+        'additionalArguments': additionalArguments
+      });
   }
 
   late Completer<void> _creatingCompleter;
@@ -275,7 +275,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('loadUrl', url);
+    return _methodChannel.invokeMethod('loadUrl', url);
   }
 
   /// Loads a document from the given string.
@@ -283,7 +283,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('loadStringContent', content);
+    return _methodChannel.invokeMethod('loadStringContent', content);
   }
 
   /// Reloads the current document.
@@ -291,7 +291,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('reload');
+    return _methodChannel.invokeMethod('reload');
   }
 
   /// Executes the given [script].
@@ -299,7 +299,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('executeScript', script);
+    return _methodChannel.invokeMethod('executeScript', script);
   }
 
   /// Posts the given JSON-formatted message to the current document.
@@ -307,7 +307,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('postWebMessage', message);
+    return _methodChannel.invokeMethod('postWebMessage', message);
   }
 
   /// Sets the user agent value.
@@ -315,7 +315,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('setUserAgent', value);
+    return _methodChannel.invokeMethod('setUserAgent', value);
   }
 
   /// Sets the background color to the provided [color].
@@ -327,7 +327,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod(
+    return _methodChannel.invokeMethod(
         'setBackgroundColor', color.value.toSigned(32));
   }
 
@@ -336,7 +336,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel
+    return _methodChannel
         .invokeMethod('setCursorPos', [position.dx, position.dy]);
   }
 
@@ -345,7 +345,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('setPointerButton',
+    return _methodChannel.invokeMethod('setPointerButton',
         <String, dynamic>{'button': button.index, 'isDown': isDown});
   }
 
@@ -354,7 +354,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('setScrollDelta', [dx, dy]);
+    return _methodChannel.invokeMethod('setScrollDelta', [dx, dy]);
   }
 
   /// Sets the surface size to the provided [size].
@@ -362,7 +362,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     if (_isDisposed) {
       return;
     }
-    await _methodChannel.invokeMethod('setSize', [size.width, size.height]);
+    return _methodChannel.invokeMethod('setSize', [size.width, size.height]);
   }
 }
 

--- a/lib/webview_windows.dart
+++ b/lib/webview_windows.dart
@@ -26,6 +26,12 @@ enum WebviewPermissionKind {
 
 enum WebviewPermissionDecision { none, allow, deny }
 
+class HistoryChanged {
+  bool canGoBack;
+  bool canGoForward;
+  HistoryChanged(this.canGoBack, this.canGoForward);
+}
+
 typedef PermissionRequestedDelegate
     = FutureOr<WebviewPermissionDecision> Function(
         String url, WebviewPermissionKind permissionKind, bool isUserInitiated);
@@ -152,6 +158,12 @@ class WebviewController extends ValueNotifier<WebviewValue> {
   /// A stream reflecting the current loading state.
   Stream<LoadingState> get loadingState => _loadingStateStreamController.stream;
 
+  final StreamController<HistoryChanged> _historyChangedStreamController =
+      StreamController<HistoryChanged>();
+
+  /// A stream reflecting the current history state.
+  Stream<HistoryChanged> get historyChanged => _historyChangedStreamController.stream;
+
   final StreamController<String> _titleStreamController =
       StreamController<String>();
 
@@ -198,6 +210,13 @@ class WebviewController extends ValueNotifier<WebviewValue> {
             case 'loadingStateChanged':
               final value = LoadingState.values[map['value']];
               _loadingStateStreamController.add(value);
+              break;
+            case 'historyChanged':
+              final value = HistoryChanged(
+                map['value']['canGoBack'],
+                map['value']['canGoForward']
+              );
+              _historyChangedStreamController.add(value);
               break;
             case 'titleChanged':
               _titleStreamController.add(map['value']);
@@ -292,6 +311,22 @@ class WebviewController extends ValueNotifier<WebviewValue> {
       return;
     }
     return _methodChannel.invokeMethod('reload');
+  }
+
+  /// Navigates the WebView to the previous page in the navigation history.
+  Future<void> goBack() async {
+    if (_isDisposed) {
+      return;
+    }
+    return _methodChannel.invokeMethod('goBack');
+  }
+
+  /// Navigates the WebView to the next page in the navigation history.
+  Future<void> goForward() async {
+    if (_isDisposed) {
+      return;
+    }
+    return _methodChannel.invokeMethod('goForward');
   }
 
   /// Executes the given [script].

--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -144,11 +144,11 @@ void Webview::RegisterEventHandlers() {
       Callback<ICoreWebView2HistoryChangedEventHandler>(
           [this](ICoreWebView2* sender, IUnknown* args) -> HRESULT {
             if (history_changed_callback_) {
-              BOOL canGoBack;
-              BOOL canGoForward;
-              sender->get_CanGoBack(&canGoBack);
-              sender->get_CanGoForward(&canGoForward);
-              history_changed_callback_({canGoBack, canGoForward});
+              BOOL can_go_back;
+              BOOL can_go_forward;
+              sender->get_CanGoBack(&can_go_back);
+              sender->get_CanGoForward(&can_go_forward);
+              history_changed_callback_({can_go_back, can_go_forward});
             }
 
             return S_OK;

--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -140,6 +140,22 @@ void Webview::RegisterEventHandlers() {
           .Get(),
       &event_registrations_.navigation_completed_token_);
 
+  webview_->add_HistoryChanged(
+      Callback<ICoreWebView2HistoryChangedEventHandler>(
+          [this](ICoreWebView2* sender, IUnknown* args) -> HRESULT {
+            if (history_changed_callback_) {
+              BOOL canGoBack;
+              BOOL canGoForward;
+              sender->get_CanGoBack(&canGoBack);
+              sender->get_CanGoForward(&canGoForward);
+              history_changed_callback_({canGoBack, canGoForward});
+            }
+
+            return S_OK;
+          })
+          .Get(),
+      &event_registrations_.history_changed_token_);
+
   webview_->add_SourceChanged(
       Callback<ICoreWebView2SourceChangedEventHandler>(
           [this](ICoreWebView2* sender, IUnknown* args) -> HRESULT {
@@ -392,6 +408,8 @@ void Webview::LoadStringContent(const std::string& content) {
 }
 
 void Webview::Reload() { webview_->Reload(); }
+void Webview::GoBack() { webview_->GoBack(); }
+void Webview::GoForward() { webview_->GoForward(); }
 
 void Webview::ExecuteScript(const std::string& script,
                             ScriptExecutedCallback callback) {

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -28,8 +28,8 @@ enum class WebviewPermissionKind {
 enum class WebviewPermissionState { Default, Allow, Deny };
 
 struct WebviewHistoryChanged {
-  BOOL canGoBack;
-  BOOL canGoForward;
+  BOOL can_go_back;
+  BOOL can_go_forward;
 };
 
 struct VirtualKeyState {

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -27,6 +27,11 @@ enum class WebviewPermissionKind {
 
 enum class WebviewPermissionState { Default, Allow, Deny };
 
+struct WebviewHistoryChanged {
+  BOOL canGoBack;
+  BOOL canGoForward;
+};
+
 struct VirtualKeyState {
  public:
   inline void set_isLeftButtonDown(bool is_down) {
@@ -67,6 +72,7 @@ struct EventRegistrations {
   EventRegistrationToken source_changed_token_{};
   EventRegistrationToken content_loading_token_{};
   EventRegistrationToken navigation_completed_token_{};
+  EventRegistrationToken history_changed_token_{};
   EventRegistrationToken document_title_changed_token_{};
   EventRegistrationToken cursor_changed_token_{};
   EventRegistrationToken got_focus_token_{};
@@ -81,6 +87,7 @@ class Webview {
 
   typedef std::function<void(const std::string&)> UrlChangedCallback;
   typedef std::function<void(WebviewLoadingState)> LoadingStateChangedCallback;
+  typedef std::function<void(WebviewHistoryChanged)> HistoryChangedCallback;
   typedef std::function<void(const std::string&)> DocumentTitleChangedCallback;
   typedef std::function<void(size_t width, size_t height)>
       SurfaceSizeChangedCallback;
@@ -108,6 +115,8 @@ class Webview {
   void LoadUrl(const std::string& url);
   void LoadStringContent(const std::string& content);
   void Reload();
+  void GoBack();
+  void GoForward();
   void ExecuteScript(const std::string& script,
                      ScriptExecutedCallback callback);
   bool PostWebMessage(const std::string& json);
@@ -121,6 +130,10 @@ class Webview {
 
   void OnLoadingStateChanged(LoadingStateChangedCallback callback) {
     loading_state_changed_callback_ = std::move(callback);
+  }
+
+  void OnHistoryChanged(HistoryChangedCallback callback) {
+    history_changed_callback_ = std::move(callback);
   }
 
   void OnSurfaceSizeChanged(SurfaceSizeChangedCallback callback) {
@@ -170,6 +183,7 @@ class Webview {
 
   UrlChangedCallback url_changed_callback_;
   LoadingStateChangedCallback loading_state_changed_callback_;
+  HistoryChangedCallback history_changed_callback_;
   DocumentTitleChangedCallback document_title_changed_callback_;
   SurfaceSizeChangedCallback surface_size_changed_callback_;
   CursorChangedCallback cursor_changed_callback_;

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -184,9 +184,9 @@ void WebviewBridge::RegisterEventHandlers() {
          flutter::EncodableValue(
           flutter::EncodableMap{
            {flutter::EncodableValue("canGoBack"),
-           flutter::EncodableValue(static_cast<bool>(historyChanged.canGoBack))},
+           flutter::EncodableValue(static_cast<bool>(historyChanged.can_go_back))},
            {flutter::EncodableValue("canGoForward"),
-           flutter::EncodableValue(static_cast<bool>(historyChanged.canGoForward))},
+           flutter::EncodableValue(static_cast<bool>(historyChanged.can_go_forward))},
           }
          )
          },

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -12,6 +12,8 @@ constexpr auto kErrorInvalidArgs = "invalidArguments";
 constexpr auto kMethodLoadUrl = "loadUrl";
 constexpr auto kMethodLoadStringContent = "loadStringContent";
 constexpr auto kMethodReload = "reload";
+constexpr auto kMethodGoBack = "goBack";
+constexpr auto kMethodGoForward = "goForward";
 constexpr auto kMethodExecuteScript = "executeScript";
 constexpr auto kMethodPostWebMessage = "postWebMessage";
 constexpr auto kMethodSetSize = "setSize";
@@ -174,6 +176,24 @@ void WebviewBridge::RegisterEventHandlers() {
     event_sink_->Success(event);
   });
 
+  webview_->OnHistoryChanged([this](WebviewHistoryChanged historyChanged) {
+    const auto event = flutter::EncodableValue(flutter::EncodableMap{
+        {flutter::EncodableValue(kEventType),
+         flutter::EncodableValue("historyChanged")},
+        {flutter::EncodableValue(kEventValue),
+         flutter::EncodableValue(
+          flutter::EncodableMap{
+           {flutter::EncodableValue("canGoBack"),
+           flutter::EncodableValue(static_cast<bool>(historyChanged.canGoBack))},
+           {flutter::EncodableValue("canGoForward"),
+           flutter::EncodableValue(static_cast<bool>(historyChanged.canGoForward))},
+          }
+         )
+         },
+    });
+    event_sink_->Success(event);
+  });
+
   webview_->OnDocumentTitleChanged([this](const std::string& title) {
     const auto event = flutter::EncodableValue(flutter::EncodableMap{
         {flutter::EncodableValue(kEventType),
@@ -318,6 +338,18 @@ void WebviewBridge::HandleMethodCall(
   // reload
   if (method_name.compare(kMethodReload) == 0) {
     webview_->Reload();
+    return result->Success();
+  }
+
+  // goBack
+  if (method_name.compare(kMethodGoBack) == 0) {
+    webview_->GoBack();
+    return result->Success();
+  }
+
+  // goForward
+  if (method_name.compare(kMethodGoForward) == 0) {
+    webview_->GoForward();
     return result->Success();
   }
 


### PR DESCRIPTION
#32

Seems to work. Adds goBack and goForward to the controller.

historyChanged stream is added for updating icons, e.g.
```dart
    HistoryChanged _historyChanged = HistoryChanged(false, false);

    ...

    _controller.historyChanged.listen((state) {
      setState(() {
        _historyChanged = HistoryChanged(state.canGoBack, state.canGoForward);
      });
    });

    ...

    IconButton(
      icon: Icon(Icons.navigate_before),
      onPressed: (_historyChanged.canGoBack) ? _controller.goBack : null,
    ),
    IconButton(
      icon: Icon(Icons.navigate_next),
      onPressed: (_historyChanged.canGoForward) ? _controller.goForward : null,
    ),
```

There's a bug with the SDKs canGoBack bool when navigating through SPA sites like flutter.dev. On flutter.dev for example, if this is the first page on launch and you click on Docs or Showcase, then go back it doesn't update canGoBack bool correctly, canGoBack will remain true. https://github.com/MicrosoftEdge/WebView2Browser this project has the same issue.

I also made the future invoke methods return instead of await since any exceptions thrown from those will send the debugger straight into the plugin side, such as already_initialized after a hot restart, so if it's returned it breaks on the main side where it can be caught and handled by the dev.