### PR TITLE
Add stop

### DIFF
--- a/lib/webview_windows.dart
+++ b/lib/webview_windows.dart
@@ -313,6 +313,14 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     return _methodChannel.invokeMethod('reload');
   }
 
+  /// Stops all navigations and pending resource fetches.
+  Future<bool?> stop() async {
+    if (_isDisposed) {
+      return false;
+    }
+    return _methodChannel.invokeMethod('stop');
+  }
+
   /// Navigates the WebView to the previous page in the navigation history.
   Future<void> goBack() async {
     if (_isDisposed) {

--- a/lib/webview_windows.dart
+++ b/lib/webview_windows.dart
@@ -314,9 +314,9 @@ class WebviewController extends ValueNotifier<WebviewValue> {
   }
 
   /// Stops all navigations and pending resource fetches.
-  Future<bool?> stop() async {
+  Future<void> stop() async {
     if (_isDisposed) {
-      return false;
+      return;
     }
     return _methodChannel.invokeMethod('stop');
   }

--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -412,9 +412,17 @@ bool Webview::Stop() {
                                               L"{}", nullptr) == S_OK;
 }
 
-void Webview::Reload() { webview_->Reload(); }
-void Webview::GoBack() { webview_->GoBack(); }
-void Webview::GoForward() { webview_->GoForward(); }
+bool Webview::Reload() {
+  return webview_->Reload() == S_OK;
+}
+
+bool Webview::GoBack() {
+  return webview_->GoBack() == S_OK;
+}
+
+bool Webview::GoForward() {
+  return webview_->GoForward() == S_OK;
+}
 
 void Webview::ExecuteScript(const std::string& script,
                             ScriptExecutedCallback callback) {

--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -407,6 +407,11 @@ void Webview::LoadStringContent(const std::string& content) {
   webview_->NavigateToString(towstring(content).c_str());
 }
 
+bool Webview::Stop() {
+  return webview_->CallDevToolsProtocolMethod(L"Page.stopLoading",
+                                              L"{}", nullptr) == S_OK;
+}
+
 void Webview::Reload() { webview_->Reload(); }
 void Webview::GoBack() { webview_->GoBack(); }
 void Webview::GoForward() { webview_->GoForward(); }

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -114,6 +114,7 @@ class Webview {
   void SetScrollDelta(double delta_x, double delta_y);
   void LoadUrl(const std::string& url);
   void LoadStringContent(const std::string& content);
+  bool Stop();
   void Reload();
   void GoBack();
   void GoForward();

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -115,9 +115,9 @@ class Webview {
   void LoadUrl(const std::string& url);
   void LoadStringContent(const std::string& content);
   bool Stop();
-  void Reload();
-  void GoBack();
-  void GoForward();
+  bool Reload();
+  bool GoBack();
+  bool GoForward();
   void ExecuteScript(const std::string& script,
                      ScriptExecutedCallback callback);
   bool PostWebMessage(const std::string& json);

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -12,6 +12,7 @@ constexpr auto kErrorInvalidArgs = "invalidArguments";
 constexpr auto kMethodLoadUrl = "loadUrl";
 constexpr auto kMethodLoadStringContent = "loadStringContent";
 constexpr auto kMethodReload = "reload";
+constexpr auto kMethodStop = "stop";
 constexpr auto kMethodGoBack = "goBack";
 constexpr auto kMethodGoForward = "goForward";
 constexpr auto kMethodExecuteScript = "executeScript";
@@ -338,6 +339,12 @@ void WebviewBridge::HandleMethodCall(
   // reload
   if (method_name.compare(kMethodReload) == 0) {
     webview_->Reload();
+    return result->Success();
+  }
+
+  // stop
+  if (method_name.compare(kMethodStop) == 0) {
+    webview_->Stop();
     return result->Success();
   }
 

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -29,6 +29,7 @@ constexpr auto kEventValue = "value";
 
 constexpr auto kErrorNotSupported = "not_supported";
 constexpr auto kScriptFailed = "script_failed";
+constexpr auto kMethodFailed = "method_failed";
 
 static const std::optional<std::pair<double, double>> GetPointFromArgs(
     const flutter::EncodableValue* args) {
@@ -338,26 +339,34 @@ void WebviewBridge::HandleMethodCall(
 
   // reload
   if (method_name.compare(kMethodReload) == 0) {
-    webview_->Reload();
-    return result->Success();
+    if (webview_->Reload()) {
+      return result->Success();
+    }
+    return result->Error(kMethodFailed);
   }
 
   // stop
   if (method_name.compare(kMethodStop) == 0) {
-    webview_->Stop();
-    return result->Success();
+    if (webview_->Stop()) {
+      return result->Success();
+    }
+    return result->Error(kMethodFailed);
   }
 
   // goBack
   if (method_name.compare(kMethodGoBack) == 0) {
-    webview_->GoBack();
-    return result->Success();
+    if (webview_->GoBack()) {
+      return result->Success();
+    }
+    return result->Error(kMethodFailed);
   }
 
   // goForward
   if (method_name.compare(kMethodGoForward) == 0) {
-    webview_->GoForward();
-    return result->Success();
+    if (webview_->GoForward()) {
+      return result->Success();
+    }
+    return result->Error(kMethodFailed);
   }
 
   // executeScript: string


### PR DESCRIPTION
There is a [Stop](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.stop?view=webview2-dotnet-1.0.902-prerelease) function but the remarks say it does not stop scripts. Their example uses the devtools method Page.stopLoading that is implemented here.

Button example:
```dart
IconButton(
  icon: (_loadingState == LoadingState.loading)
        ? Icon(Icons.close) : Icon(Icons.refresh),
  onPressed: (_loadingState == LoadingState.loading)
        ? _controller.stop : _controller.reload,
),
```