### PR TITLE
TextureBridgeFallback: Only lock mutex when returning a non-null buffer

### DIFF
--- a/windows/texture_bridge_fallback.cc
+++ b/windows/texture_bridge_fallback.cc
@@ -118,7 +118,12 @@ const FlutterDesktopPixelBuffer* TextureBridgeFallback::CopyPixelBuffer(
     ProcessFrame(last_frame_);
   }
 
-  // Gets unlocked in the FlutterDesktopPixelBuffer's release callback
-  buffer_mutex_.lock();
-  return pixel_buffer_.get();
+  auto buffer = pixel_buffer_.get();
+  // Only lock the mutex if the buffer is not null
+  // (to ensure the release callback gets called)
+  if (buffer) {
+    // Gets unlocked in the FlutterDesktopPixelBuffer's release callback.
+    buffer_mutex_.lock();
+  }
+  return buffer;
 }


### PR DESCRIPTION
Fixes an issue in `TextureBridgeFallback::CopyPixelBuffer` where the mutex gets locked even if the `FlutterDesktopPixelBuffer` is null which will make the mutex stay locked forever.

Fixes #85
Fixes #86 