### PR TITLE
Expose OpenDevTools function

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,22 +96,37 @@ class _ExampleBrowser extends State<ExampleBrowser> {
           children: [
             Card(
               elevation: 0,
-              child: TextField(
-                decoration: InputDecoration(
-                    hintText: 'URL',
-                    contentPadding: EdgeInsets.all(10.0),
-                    suffixIcon: IconButton(
-                      icon: Icon(Icons.refresh),
-                      onPressed: () {
-                        _controller.reload();
-                      },
-                    )),
-                textAlignVertical: TextAlignVertical.center,
-                controller: _textController,
-                onSubmitted: (val) {
-                  _controller.loadUrl(val);
-                },
-              ),
+              child: Row(children: [
+                
+                Expanded(
+                  child: TextField(
+                    decoration: InputDecoration(
+                      hintText: 'URL',
+                      contentPadding: EdgeInsets.all(10.0),
+                    ),
+                    textAlignVertical: TextAlignVertical.center,
+                    controller: _textController,
+                    onSubmitted: (val) {
+                      _controller.loadUrl(val);
+                    },
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.refresh),
+                  splashRadius: 20,
+                  onPressed: () {
+                    _controller.reload();
+                  },
+                ),
+                IconButton(
+                  icon: Icon(Icons.developer_mode),
+                  tooltip: 'Open DevTools',
+                  splashRadius: 20,
+                  onPressed: () {
+                    _controller.openDevTools();
+                  },
+                )
+              ]),
             ),
             Expanded(
                 child: Card(

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -351,6 +351,15 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     return _methodChannel.invokeMethod('setCacheDisabled', disabled);
   }
 
+    /// Opens the Browser DevTools in seperate Window
+  Future<void> openDevTools() async {
+    if (_isDisposed) {
+      return;
+    }
+    assert(value.isInitialized);
+    return _methodChannel.invokeMethod('openDevTools');
+  }
+
   /// Sets the background color to the provided [color].
   ///
   /// Due to a limitation of the underlying WebView implementation,

--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -387,6 +387,14 @@ void Webview::SetSurfaceSize(size_t width, size_t height) {
   }
 }
 
+bool Webview::OpenDevTools() {
+  if (!IsValid()) {
+    return false;
+  }
+  webview_->OpenDevToolsWindow();
+  return true;
+}
+
 bool Webview::ClearCookies() {
   if (!IsValid()) {
     return false;

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -132,6 +132,7 @@ class Webview {
   bool SetCacheDisabled(bool disabled);
   void SetPopupWindowPolicy(WebviewPopupWindowPolicy policy);
   bool SetUserAgent(const std::string& user_agent);
+  bool OpenDevTools();
   bool SetBackgroundColor(int32_t color);
   bool Suspend();
   bool Resume();

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -29,6 +29,7 @@ constexpr auto kMethodSetPointerButton = "setPointerButton";
 constexpr auto kMethodSetScrollDelta = "setScrollDelta";
 constexpr auto kMethodSetUserAgent = "setUserAgent";
 constexpr auto kMethodSetBackgroundColor = "setBackgroundColor";
+constexpr auto kMethodOpenDevTools = "openDevTools";
 constexpr auto kMethodSuspend = "suspend";
 constexpr auto kMethodResume = "resume";
 constexpr auto kMethodClearCookies = "clearCookies";
@@ -473,6 +474,14 @@ void WebviewBridge::HandleMethodCall(
                            "Setting the background color failed.");
     }
     return result->Error(kErrorInvalidArgs);
+  }
+
+  // openDevTools
+  if (method_name.compare(kMethodOpenDevTools) == 0) {
+    if (webview_->OpenDevTools()) {
+      return result->Success();
+    }
+    return result->Error(kMethodFailed);
   }
 
   // clearCookies


### PR DESCRIPTION
This PR adds the WebView2 function OpenDevTools()  to the WebviewController.  I am not very familiar with C++ but i tried my best to go with the existing style of the implementation.

To be able to debug web apps running in the webview i added the function and created the PR to provide the function to others and not maintain my own Fork of the project as i find this function very crucial when running a custom web app in the WebView with heavy communication between Flutter and JS.

I added a button opening the DevTools to the example as well:
![image](https://user-images.githubusercontent.com/43518397/155813270-14973ca6-40a9-4e97-9f04-0a1a65a0a86f.png)


Thanks for the awesome plugin!
