### PR TITLE
Update TextureBridgeGpu to match upstreamed d3d texture interface

### DIFF
--- a/windows/texture_bridge.cc
+++ b/windows/texture_bridge.cc
@@ -10,7 +10,7 @@
 #include "util/direct3d11.interop.h"
 
 namespace {
-const int kNumBuffers = 2;
+const int kNumBuffers = 1;
 }  // namespace
 
 TextureBridge::TextureBridge(GraphicsContext* graphics_context,

--- a/windows/texture_bridge_gpu.h
+++ b/windows/texture_bridge_gpu.h
@@ -19,5 +19,5 @@ class TextureBridgeGpu : public TextureBridge {
   winrt::com_ptr<IDXGIResource> dxgi_surface_;
 
   void ProcessFrame(winrt::com_ptr<ID3D11Texture2D> src_texture);
-  void EnsureSurface(uint32_t width, uint32_t height, bool& is_exact_size);
+  void EnsureSurface(uint32_t width, uint32_t height);
 };

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -120,12 +120,12 @@ WebviewBridge::WebviewBridge(flutter::BinaryMessenger* messenger,
                              std::unique_ptr<Webview> webview)
     : webview_(std::move(webview)), texture_registrar_(texture_registrar) {
 #ifdef HAVE_FLUTTER_D3D_TEXTURE
-  texture_bridge_ = std::make_unique<TextureBridgeGpu>(
-      graphics_context, webview_->surface());
+  texture_bridge_ =
+      std::make_unique<TextureBridgeGpu>(graphics_context, webview_->surface());
 
   flutter_texture_ =
       std::make_unique<flutter::TextureVariant>(flutter::GpuSurfaceTexture(
-          kFlutterDesktopGpuSurfaceTypeDxgi,
+          kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
           [bridge = static_cast<TextureBridgeGpu*>(texture_bridge_.get())](
               size_t width,
               size_t height) -> const FlutterDesktopGpuSurfaceDescriptor* {


### PR DESCRIPTION
Now that https://github.com/flutter/engine/pull/26840 has been merged, the `TextureBridgeGpu` needs to be updated to initialize the surface descriptor's struct size.