### PR TITLE
Fallback texture bridge: Ensure mutex is unlocked before destroying it

### DIFF
--- a/windows/texture_bridge_fallback.cc
+++ b/windows/texture_bridge_fallback.cc
@@ -10,6 +10,10 @@ TextureBridgeFallback::TextureBridgeFallback(
     ABI::Windows::UI::Composition::IVisual* visual)
     : TextureBridge(graphics_context, visual) {}
 
+TextureBridgeFallback::~TextureBridgeFallback() {
+  const std::lock_guard<std::mutex> lock(buffer_mutex_);
+}
+
 void TextureBridgeFallback::ProcessFrame(
     winrt::com_ptr<ID3D11Texture2D> src_texture) {
   D3D11_TEXTURE2D_DESC desc;

--- a/windows/texture_bridge_fallback.h
+++ b/windows/texture_bridge_fallback.h
@@ -10,6 +10,7 @@ class TextureBridgeFallback : public TextureBridge {
  public:
   TextureBridgeFallback(GraphicsContext* graphics_context,
                         ABI::Windows::UI::Composition::IVisual* visual);
+  ~TextureBridgeFallback() override;
 
   const FlutterDesktopPixelBuffer* CopyPixelBuffer(size_t width, size_t height);
 


### PR DESCRIPTION
Fixes #140