### PR TITLE
TextureBridgeGpu: Fix resume

### DIFF
--- a/windows/texture_bridge.h
+++ b/windows/texture_bridge.h
@@ -64,7 +64,7 @@ class TextureBridge {
   EventRegistrationToken on_closed_token_ = {};
   EventRegistrationToken on_frame_arrived_token_ = {};
 
-  void StopInternal();
+  virtual void StopInternal();
   void OnFrameArrived();
   bool ShouldDropFrame();
 

--- a/windows/texture_bridge_gpu.cc
+++ b/windows/texture_bridge_gpu.cc
@@ -45,8 +45,6 @@ void TextureBridgeGpu::EnsureSurface(uint32_t width, uint32_t height) {
     dstDesc.SampleDesc.Quality = 0;
     dstDesc.Usage = D3D11_USAGE_DEFAULT;
 
-    surface_ = nullptr;
-
     if (!SUCCEEDED(graphics_context_->d3d_device()->CreateTexture2D(
             &dstDesc, nullptr, surface_.put()))) {
       std::cerr << "Creating intermediate texture failed" << std::endl;
@@ -89,4 +87,12 @@ TextureBridgeGpu::GetSurfaceDescriptor(size_t width, size_t height) {
   }
 
   return &surface_descriptor_;
+}
+
+void TextureBridgeGpu::StopInternal() {
+  TextureBridge::StopInternal();
+
+  // For some reason, the destination surface needs to be recreated upon
+  // resuming. Force |EnsureSurface| to create a new one by resetting it here.
+  surface_ = nullptr;
 }

--- a/windows/texture_bridge_gpu.h
+++ b/windows/texture_bridge_gpu.h
@@ -12,6 +12,9 @@ class TextureBridgeGpu : public TextureBridge {
   const FlutterDesktopGpuSurfaceDescriptor* GetSurfaceDescriptor(size_t width,
                                                                  size_t height);
 
+ protected:
+  void StopInternal() override;
+
  private:
   FlutterDesktopGpuSurfaceDescriptor surface_descriptor_ = {};
   Size surface_size_ = {0, 0};


### PR DESCRIPTION
Prevent the WebView from staying blank after resuming it. Only affects `TextureBridgeGpu`.