### PR TITLE
Resolve error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.

### DIFF
--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -487,7 +487,7 @@ class _WebviewState extends State<Webview> {
     _controller._permissionRequested = widget.permissionRequested;
 
     // Report initial surface size
-    WidgetsBinding.instance.addPostFrameCallback((_) => _reportSurfaceSize());
+    WidgetsBinding.instance?.addPostFrameCallback((_) => _reportSurfaceSize());
 
     _cursorSubscription = _controller._cursor.listen((cursor) {
       setState(() {


### PR DESCRIPTION
Resolve error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.

On Flutter Stable version 2.10.5 and Dart version 2.16.2