### PR TITLE
Implement Pointer Input (Touch)

### DIFF
--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -26,3 +26,7 @@ enum WebviewPermissionDecision { none, allow, deny }
 /// [deny] suppresses popups.
 /// [sameWindow] displays popup contents in the current WebView.
 enum WebviewPopupWindowPolicy { allow, deny, sameWindow }
+
+// Event kind
+// Matches the types defined for CoreWebView2PointerEventKind.
+enum WebviewPointerEventKind { activate, down, enter, leave, up, update }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -6,6 +6,10 @@ enum LoadingState { none, loading, navigationCompleted }
 // Order must match WebviewPointerButton (see webview.h)
 enum PointerButton { none, primary, secondary, tertiary }
 
+/// Pointer Event kind
+// Order must match WebviewPointerEventKind (see webview.h)
+enum WebviewPointerEventKind { activate, down, enter, leave, up, update }
+
 /// Permission kind
 // Order must match WebviewPermissionKind (see webview.h)
 enum WebviewPermissionKind {
@@ -26,7 +30,3 @@ enum WebviewPermissionDecision { none, allow, deny }
 /// [deny] suppresses popups.
 /// [sameWindow] displays popup contents in the current WebView.
 enum WebviewPopupWindowPolicy { allow, deny, sameWindow }
-
-// Event kind
-// Matches the types defined for CoreWebView2PointerEventKind.
-enum WebviewPointerEventKind { activate, down, enter, leave, up, update }

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -413,14 +413,14 @@ class WebviewController extends ValueNotifier<WebviewValue> {
   }
 
   /// Sends a Pointer (Touch) update
-  Future<void> _setPointerUpdate(WebviewPointerEventKind kind, Offset position,
-      double size, double pressure) async {
+  Future<void> _setPointerUpdate(WebviewPointerEventKind kind, int pointer,
+      Offset position, double size, double pressure) async {
     if (_isDisposed) {
       return;
     }
     assert(value.isInitialized);
     return _methodChannel.invokeMethod('setPointerUpdate',
-        [kind.winIntValue, position.dx, position.dy, size, pressure]);
+        [pointer, kind.index, position.dx, position.dy, size, pressure]);
   }
 
   /// Moves the virtual cursor to [position].
@@ -543,6 +543,7 @@ class _WebviewState extends State<Webview> {
                       if (ev.kind == PointerDeviceKind.touch) {
                         _controller._setPointerUpdate(
                             WebviewPointerEventKind.down,
+                            ev.pointer,
                             ev.localPosition,
                             ev.size,
                             ev.pressure);
@@ -557,6 +558,7 @@ class _WebviewState extends State<Webview> {
                       if (ev.kind == PointerDeviceKind.touch) {
                         _controller._setPointerUpdate(
                             WebviewPointerEventKind.up,
+                            ev.pointer,
                             ev.localPosition,
                             ev.size,
                             ev.pressure);
@@ -579,6 +581,7 @@ class _WebviewState extends State<Webview> {
                       if (ev.kind == PointerDeviceKind.touch) {
                         _controller._setPointerUpdate(
                             WebviewPointerEventKind.update,
+                            ev.pointer,
                             ev.localPosition,
                             ev.size,
                             ev.pressure);
@@ -611,24 +614,5 @@ class _WebviewState extends State<Webview> {
   void dispose() {
     super.dispose();
     _cursorSubscription?.cancel();
-  }
-}
-
-extension WebviewPointerEventKindExt on WebviewPointerEventKind {
-  int get winIntValue {
-    switch (this) {
-      case WebviewPointerEventKind.activate:
-        return 587; // WM_POINTERACTIVATE
-      case WebviewPointerEventKind.down:
-        return 582; // WM_POINTERDOWN
-      case WebviewPointerEventKind.enter:
-        return 585; // WM_POINTERENTER
-      case WebviewPointerEventKind.leave:
-        return 586; // WM_POINTERLEAVE
-      case WebviewPointerEventKind.up:
-        return 583; // WM_POINTERUP
-      case WebviewPointerEventKind.update:
-        return 581; // WM_POINTERUPDATE
-    }
   }
 }

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -14,6 +14,8 @@ enum class WebviewLoadingState { None, Loading, NavigationCompleted };
 
 enum class WebviewPointerButton { None, Primary, Secondary, Tertiary };
 
+enum class WebviewPointerEventKind { Activate, Down, Enter, Leave, Up, Update };
+
 enum class WebviewPermissionKind {
   Unknown,
   Microphone,
@@ -116,7 +118,12 @@ class Webview {
 
   void SetSurfaceSize(size_t width, size_t height);
   void SetCursorPos(double x, double y);
-  void SetPointerUpdate(int32_t event, double x, double y, double size, double pressure);
+  void SetPointerUpdate(int32_t pointer,
+                        WebviewPointerEventKind eventKind,
+                        double x,
+                        double y,
+                        double size,
+                        double pressure);
   void SetPointerButtonState(WebviewPointerButton button, bool isDown);
   void SetScrollDelta(double delta_x, double delta_y);
   void LoadUrl(const std::string& url);

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -116,6 +116,7 @@ class Webview {
 
   void SetSurfaceSize(size_t width, size_t height);
   void SetCursorPos(double x, double y);
+  void SetPointerUpdate(int32_t event, double x, double y, double size, double pressure);
   void SetPointerButtonState(WebviewPointerButton button, bool isDown);
   void SetScrollDelta(double delta_x, double delta_y);
   void LoadUrl(const std::string& url);

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -25,6 +25,7 @@ constexpr auto kMethodExecuteScript = "executeScript";
 constexpr auto kMethodPostWebMessage = "postWebMessage";
 constexpr auto kMethodSetSize = "setSize";
 constexpr auto kMethodSetCursorPos = "setCursorPos";
+constexpr auto kMethodSetPointerUpdate = "setPointerUpdate";
 constexpr auto kMethodSetPointerButton = "setPointerButton";
 constexpr auto kMethodSetScrollDelta = "setScrollDelta";
 constexpr auto kMethodSetUserAgent = "setUserAgent";
@@ -311,6 +312,27 @@ void WebviewBridge::HandleMethodCall(
     const auto point = GetPointFromArgs(method_call.arguments());
     if (point) {
       webview_->SetCursorPos(point->first, point->second);
+      return result->Success();
+    }
+    return result->Error(kErrorInvalidArgs);
+  }
+
+  // setPointerUpdate: [int event, double x, double y, double size, double pressure]
+  if (method_name.compare(kMethodSetPointerUpdate) == 0) {
+      const flutter::EncodableList* list =
+      std::get_if<flutter::EncodableList>(method_call.arguments());
+    if (!list || list->size() != 5) {
+      return result->Error(kErrorInvalidArgs);
+    }
+
+    const auto event = std::get_if<int32_t>(&(*list)[0]);
+    const auto x = std::get_if<double>(&(*list)[1]);
+    const auto y = std::get_if<double>(&(*list)[2]);
+    const auto size = std::get_if<double>(&(*list)[3]);
+    const auto pressure = std::get_if<double>(&(*list)[4]);
+
+    if (event && x && y && size && pressure) {
+      webview_->SetPointerUpdate(*event, *x, *y, *size, *pressure);
       return result->Success();
     }
     return result->Error(kErrorInvalidArgs);

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -317,22 +317,24 @@ void WebviewBridge::HandleMethodCall(
     return result->Error(kErrorInvalidArgs);
   }
 
-  // setPointerUpdate: [int event, double x, double y, double size, double pressure]
+  // setPointerUpdate: 
+  // [int pointer, int event, double x, double y, double size, double pressure]
   if (method_name.compare(kMethodSetPointerUpdate) == 0) {
       const flutter::EncodableList* list =
       std::get_if<flutter::EncodableList>(method_call.arguments());
-    if (!list || list->size() != 5) {
+    if (!list || list->size() != 6) {
       return result->Error(kErrorInvalidArgs);
     }
 
-    const auto event = std::get_if<int32_t>(&(*list)[0]);
-    const auto x = std::get_if<double>(&(*list)[1]);
-    const auto y = std::get_if<double>(&(*list)[2]);
-    const auto size = std::get_if<double>(&(*list)[3]);
-    const auto pressure = std::get_if<double>(&(*list)[4]);
+    const auto pointer = std::get_if<int32_t>(&(*list)[0]);
+    const auto event = std::get_if<int32_t>(&(*list)[1]);
+    const auto x = std::get_if<double>(&(*list)[2]);
+    const auto y = std::get_if<double>(&(*list)[3]);
+    const auto size = std::get_if<double>(&(*list)[4]);
+    const auto pressure = std::get_if<double>(&(*list)[5]);
 
-    if (event && x && y && size && pressure) {
-      webview_->SetPointerUpdate(*event, *x, *y, *size, *pressure);
+    if (pointer && event && x && y && size && pressure) {
+      webview_->SetPointerUpdate(*pointer, static_cast<WebviewPointerEventKind>(*event), *x, *y, *size, *pressure);
       return result->Success();
     }
     return result->Error(kErrorInvalidArgs);

--- a/windows/webview_host.cc
+++ b/windows/webview_host.cc
@@ -84,6 +84,18 @@ void WebviewHost::CreateWebview(HWND hwnd, bool offscreen_only,
       });
 }
 
+void WebviewHost::CreateWebViewPointerInfo(PointerInfoCreationCallback callback) {
+
+  ICoreWebView2PointerInfo *pointer;
+  auto hr = webview_env_->CreateCoreWebView2PointerInfo(&pointer);
+
+  if (FAILED(hr)) {
+    callback(nullptr, WebviewCreationError::create(hr, "CreateWebViewPointerInfo failed."));
+  } else if (SUCCEEDED(hr)) {
+    callback(std::move(wil::com_ptr<ICoreWebView2PointerInfo>(pointer)), nullptr);
+  }
+}
+
 void WebviewHost::CreateWebViewCompositionController(
     HWND hwnd, CompositionControllerCreationCallback callback) {
   auto hr = webview_env_->CreateCoreWebView2CompositionController(

--- a/windows/webview_host.h
+++ b/windows/webview_host.h
@@ -32,6 +32,9 @@ class WebviewHost {
   typedef std::function<void(wil::com_ptr<ICoreWebView2CompositionController>,
                              std::unique_ptr<WebviewCreationError>)>
       CompositionControllerCreationCallback;
+  typedef std::function<void(wil::com_ptr<ICoreWebView2PointerInfo>,
+                             std::unique_ptr<WebviewCreationError>)>
+      PointerInfoCreationCallback;
 
   static std::unique_ptr<WebviewHost> Create(
       WebviewPlatform* platform,
@@ -41,6 +44,8 @@ class WebviewHost {
 
   void CreateWebview(HWND hwnd, bool offscreen_only, bool owns_window,
                      WebviewCreationCallback callback);
+
+  void CreateWebViewPointerInfo(PointerInfoCreationCallback cb);
 
   winrt::com_ptr<ABI::Windows::UI::Composition::ICompositor> compositor()
       const {


### PR DESCRIPTION
This is a rather basic implementation for single touch events.
I guess it can be seen that this fixes #111.

I had some strange issues, like that `onPointerHover` did send me events for touch devices, but `ev.kind` was set to `.unknown` or even `.mouse`.  (Devices like the "Windows Simulator" [Part of VS 2019] would do this)

I did not investigate this deeper nor did i implement multi-touch with it. (matter of fact: it is broken and the first firing event wins the race to get the touch event)

It is based on [Microsofts basic example](https://github.com/microsoft/microsoft-ui-xaml/blob/d08303e6a2f4e2f6a51a3fe3234885723e5327b1/dev/WebView2/WebView2.cpp#L1145) of touch events, for more functionality (like Multitouch) my guess would be that a matrix like [WebView2Samples](https://github.com/MicrosoftEdge/WebView2Samples/blob/0d30a0809aa082a24220c99e5715df8ed11825b8/SampleApps/WebView2APISample/ViewComponent.cpp#L854) has needs to be implemented.