### PR TITLE
Remove Workaround for SendScroll

### DIFF
--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -569,29 +569,19 @@ void Webview::SendScroll(double delta, bool horizontal) {
 
   auto offset = static_cast<short>(delta * kScrollMultiplier);
 
-  // TODO Remove this workaround
-  //
-  // For some reason, the composition controller only handles mousewheel events
-  // if a mouse button is down.
-  // -> Emulate a down button while sending the wheel event (a virtual key
-  //    doesn't work)
-  composition_controller_->SendMouseInput(
-      COREWEBVIEW2_MOUSE_EVENT_KIND_X_BUTTON_DOWN,
-      COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE, 0, last_cursor_pos_);
+  POINT point;
+  point.x = 0;
+  point.y = 0;
 
   if (horizontal) {
     composition_controller_->SendMouseInput(
         COREWEBVIEW2_MOUSE_EVENT_KIND_HORIZONTAL_WHEEL, virtual_keys_.state(),
-        offset, last_cursor_pos_);
+        offset, point);
   } else {
     composition_controller_->SendMouseInput(COREWEBVIEW2_MOUSE_EVENT_KIND_WHEEL,
                                             virtual_keys_.state(), offset,
-                                            last_cursor_pos_);
+                                            point);
   }
-
-  composition_controller_->SendMouseInput(
-      COREWEBVIEW2_MOUSE_EVENT_KIND_X_BUTTON_UP,
-      COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE, 0, last_cursor_pos_);
 }
 
 void Webview::SetScrollDelta(double delta_x, double delta_y) {


### PR DESCRIPTION
(I guess this is more a open discussion on how to fix this issue)


I wanted to figure out why scrolling in an `<iframe>` was (and still is) not working. (Testpage: https://tlercher.de/iframetest.html)

After some tinkering i noticed that `MOUSEWHEEL`-scrolling works when the points are set to 0.
I guess this probably better than before?


Any idea whats going on inside of `SendMouseInput` is going on? Even with screen coordinates (converted via `::ScreenToClient(HWND, POINT)`) it doesn't want to work.