### PR TITLE
Enable D3D texture bridge by default

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://jns.io
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=2.8.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PROJECT_NAME "webview_windows")
 set(WIL_VERSION "1.0.220914.1")
 set(WEBVIEW_VERSION "1.0.1210.39")
 
-message("CMake system version is ${CMAKE_SYSTEM_VERSION} (using SDK ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})")
+message(VERBOSE "CMake system version is ${CMAKE_SYSTEM_VERSION} (using SDK ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})")
 
 project(${PROJECT_NAME} LANGUAGES CXX)
 
@@ -51,7 +51,7 @@ add_library(${PLUGIN_NAME} SHARED
   "util/string_converter.cc"
 )
 
-if(FLUTTER_WEBVIEW_WINDOWS_USE_D3D_TEXTURE)
+if(NOT FLUTTER_WEBVIEW_WINDOWS_USE_TEXTURE_FALLBACK)
   message(STATUS "Building with D3D texture support.")
   target_compile_definitions("${PLUGIN_NAME}" PRIVATE
     HAVE_FLUTTER_D3D_TEXTURE


### PR DESCRIPTION
Defaults to `TextureBridgeGpu`. The legacy texture bridge can still be used by enabling `FLUTTER_WEBVIEW_WINDOWS_USE_TEXTURE_FALLBACK` in the top-level project's `CMakeLists.txt`.

This increases the minimum required Flutter version to 3.3 though.