### PR TITLE
Fixes string casting of paths that may contains Unicode characters.

### DIFF
--- a/windows/webview_host.cc
+++ b/windows/webview_host.cc
@@ -11,8 +11,8 @@ using namespace Microsoft::WRL;
 
 // static
 std::unique_ptr<WebviewHost> WebviewHost::Create(
-    WebviewPlatform* platform, std::optional<std::string> user_data_directory,
-    std::optional<std::string> browser_exe_path,
+    WebviewPlatform* platform, std::optional<std::wstring> user_data_directory,
+    std::optional<std::wstring> browser_exe_path,
     std::optional<std::string> arguments) {
   wil::com_ptr<CoreWebView2EnvironmentOptions> opts;
   if (arguments.has_value()) {
@@ -21,23 +21,11 @@ std::unique_ptr<WebviewHost> WebviewHost::Create(
     opts->put_AdditionalBrowserArguments(warguments.c_str());
   }
 
-  std::optional<std::wstring> user_data_dir;
-  if (user_data_directory.has_value()) {
-    user_data_dir =
-        std::wstring(user_data_directory->begin(), user_data_directory->end());
-  }
-
-  std::optional<std::wstring> browser_path;
-  if (browser_exe_path.has_value()) {
-    browser_path =
-        std::wstring(browser_exe_path->begin(), browser_exe_path->end());
-  }
-
   std::promise<HRESULT> result_promise;
   wil::com_ptr<ICoreWebView2Environment> env;
   auto result = CreateCoreWebView2EnvironmentWithOptions(
-      browser_path.has_value() ? browser_path->c_str() : nullptr,
-      user_data_dir.has_value() ? user_data_dir->c_str() : nullptr, opts.get(),
+      browser_exe_path.has_value() ? browser_exe_path->c_str() : nullptr,
+      user_data_directory.has_value() ? user_data_directory->c_str() : nullptr, opts.get(),
       Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
           [&promise = result_promise, &ptr = env](
               HRESULT r, ICoreWebView2Environment* env) -> HRESULT {

--- a/windows/webview_host.h
+++ b/windows/webview_host.h
@@ -38,8 +38,8 @@ class WebviewHost {
 
   static std::unique_ptr<WebviewHost> Create(
       WebviewPlatform* platform,
-      std::optional<std::string> user_data_directory = std::nullopt,
-      std::optional<std::string> browser_exe_path = std::nullopt,
+      std::optional<std::wstring> user_data_directory = std::nullopt,
+      std::optional<std::wstring> browser_exe_path = std::nullopt,
       std::optional<std::string> arguments = std::nullopt);
 
   void CreateWebview(HWND hwnd, bool offscreen_only, bool owns_window,

--- a/windows/webview_platform.cc
+++ b/windows/webview_platform.cc
@@ -59,7 +59,7 @@ bool WebviewPlatform::IsGraphicsCaptureSessionSupported() {
   return !!is_supported;
 }
 
-std::optional<std::string> WebviewPlatform::GetDefaultDataDirectory() {
+std::optional<std::wstring> WebviewPlatform::GetDefaultDataDirectory() {
   PWSTR path_tmp;
   if (!SUCCEEDED(
           SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &path_tmp))) {
@@ -73,5 +73,5 @@ std::optional<std::string> WebviewPlatform::GetDefaultDataDirectory() {
   path /= "flutter_webview_windows";
   path /= std::filesystem::path(filename).stem();
 
-  return path.string();
+  return path.wstring();
 }

--- a/windows/webview_platform.h
+++ b/windows/webview_platform.h
@@ -13,7 +13,7 @@ class WebviewPlatform {
  public:
   WebviewPlatform();
   bool IsSupported() { return valid_; }
-  std::optional<std::string> GetDefaultDataDirectory();
+  std::optional<std::wstring> GetDefaultDataDirectory();
   bool IsGraphicsCaptureSessionSupported();
   GraphicsContext* graphics_context() const {
     return graphics_context_.get();

--- a/windows/webview_windows_plugin.cc
+++ b/windows/webview_windows_plugin.cc
@@ -121,20 +121,27 @@ void WebviewWindowsPlugin::HandleMethodCall(
 
     const auto& map = std::get<flutter::EncodableMap>(*method_call.arguments());
 
+    std::optional<std::wstring> browser_exe_wpath = std::nullopt;
     std::optional<std::string> browser_exe_path =
         GetOptionalValue<std::string>(map, "browserExePath");
+    if (browser_exe_path) {
+      browser_exe_wpath = util::Utf16FromUtf8(*browser_exe_path);
+    }
 
+    std::optional<std::wstring> user_data_wpath = std::nullopt;
     std::optional<std::string> user_data_path =
         GetOptionalValue<std::string>(map, "userDataPath");
-    if (!user_data_path) {
-      user_data_path = platform_->GetDefaultDataDirectory();
+    if (user_data_path) {
+      user_data_wpath = util::Utf16FromUtf8(*user_data_path);
+    } else {
+      user_data_wpath = platform_->GetDefaultDataDirectory();
     }
 
     std::optional<std::string> additional_args =
         GetOptionalValue<std::string>(map, "additionalArguments");
 
     webview_host_ = std::move(WebviewHost::Create(
-        platform_.get(), user_data_path, browser_exe_path, additional_args));
+        platform_.get(), user_data_wpath, browser_exe_wpath, additional_args));
     if (!webview_host_) {
       return result->Error(kErrorCodeEnvironmentCreationFailed);
     }


### PR DESCRIPTION
This PR fixed the `user_data_directory` string casting, which will causes some unexcepted behaviors if string contains Unicode characters:

### 1. If the user has permission to create directorys, for example:
Excepted user data directory:
> C:\Users\Username\AppData\Roaming\myapp\缓存

Actually user data directory:
> C:\Users\Username\AppData\Roaming\myapp\￧ﾼﾓ￥ﾭﾘ

The WebView2 will creates the directory as a garbled name `￧ﾼﾓ￥ﾭﾘ`, which is unexcepted.

### 2. If the user does not have write permission, for example, a windows username with Unicode characters:
Excepted user data directory:
> C:\Users\缓存\AppData\Roaming\myapp\weview\cache

Actually user data directory:
>C:\Users\￧ﾼﾓ￥ﾭﾘ\AppData\Roaming\myapp\weview\cache

This time the Weview2 will try to create directories `C:\Users\￧ﾼﾓ￥ﾭﾘ` and may got failed.

