### PR TITLE
Fix Visual Studio 17.6 builds

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -72,12 +72,7 @@ else()
 endif()
 
 apply_standard_settings(${PLUGIN_NAME})
-if (MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.29.30129 AND CMAKE_VERSION VERSION_GREATER 3.20.3)
-  # CMake 3.20.4+
-  target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_23) # ensure /std:c++latest for std::format
-else()
-  target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_20) # ensure /std:c++latest for std::format
-endif()
+target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_20) # For std::format support
 
 set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 


### PR DESCRIPTION
Starting with Visual Studio 17.6 (and 16.11.14), MSVC now supports all C++20 features including `std::format` by just using `/std:c++20` as opposed to `/std:c++latest`.

Fixes #239
Fixes #247
Fixes #251


