### PR TITLE
enable scrolling with Trackpad

### DIFF
--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -708,6 +708,10 @@ class _WebviewState extends State<Webview> {
                             -signal.scrollDelta.dx, -signal.scrollDelta.dy);
                       }
                     },
+                    onPointerPanZoomUpdate: (signal) {
+                      _controller._setScrollDelta(
+                          signal.panDelta.dx, signal.panDelta.dy);
+                    },
                     child: MouseRegion(
                         cursor: _cursor,
                         child: Texture(


### PR DESCRIPTION
I can scroll with the mouse wheel, but I cannot with the trackpad.

This is because scroll events from the trackpad are sent via onPointerPanZoomUpdate, not onPointerSignal.
https://docs.flutter.dev/release/breaking-changes/trackpad-gestures

By sending the amount of scroll, `panDelta` in `PointerPanZoomUpdateEvent`, to the webview, I can scroll with the trackpad.

Related issues: https://github.com/jnschulze/flutter-webview-windows/issues/258
