### PR TITLE
Explicitly enabled experimental coroutine support on MSVC compilers

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -51,6 +51,10 @@ add_library(${PLUGIN_NAME} SHARED
   "util/string_converter.cc"
 )
 
+if(MSVC)
+    target_compile_options(${PLUGIN_NAME} PRIVATE "/await")
+endif()
+
 if(NOT FLUTTER_WEBVIEW_WINDOWS_USE_TEXTURE_FALLBACK)
   message(STATUS "Building with D3D texture support.")
   target_compile_definitions("${PLUGIN_NAME}" PRIVATE
@@ -67,7 +71,7 @@ else()
   )
   # Enable AVX2 for pixel buffer conversions
   if(MSVC)
-    target_compile_options(${PLUGIN_NAME} PRIVATE "/arch:AVX2")
+    target_compile_options(${PLUGIN_NAME} PRIVATE "/arch:AVX2" "/await")
   endif()
 endif()
 


### PR DESCRIPTION
Fixes compilation error:

`fatal  error C1189: #error:  The <experimental/coroutine> and <experimental/resumable> headers are only supported with /await and implement pre-C++20 coroutine support. Use <coroutine> for standard C++20 coroutines. `

In some scenarios.