### PR TITLE
feat:Change setPopupWindowPolicy to a more flexible newWindowRequested event.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -147,7 +147,8 @@ class _ExampleBrowser extends State<ExampleBrowser> {
                       children: [
                         Webview(_controller,
                             permissionRequested: _onPermissionRequested,
-                            newWindowRequested: (url) {
+                            newWindowRequested: (details) {
+                          print(details.toString());
                           return WebviewPopupWindowPolicy.deny;
                         }),
                         StreamBuilder<LoadingState>(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,6 @@ class _ExampleBrowser extends State<ExampleBrowser> {
       }));
 
       await _controller.setBackgroundColor(Colors.transparent);
-      await _controller.setPopupWindowPolicy(WebviewPopupWindowPolicy.deny);
       await _controller.loadUrl('https://flutter.dev');
 
       if (!mounted) return;
@@ -146,10 +145,11 @@ class _ExampleBrowser extends State<ExampleBrowser> {
                     clipBehavior: Clip.antiAliasWithSaveLayer,
                     child: Stack(
                       children: [
-                        Webview(
-                          _controller,
-                          permissionRequested: _onPermissionRequested,
-                        ),
+                        Webview(_controller,
+                            permissionRequested: _onPermissionRequested,
+                            newWindowRequested: (url) {
+                          return WebviewPopupWindowPolicy.deny;
+                        }),
                         StreamBuilder<LoadingState>(
                             stream: _controller.loadingState,
                             builder: (context, snapshot) {

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -502,17 +502,6 @@ class WebviewController extends ValueNotifier<WebviewValue> {
     return _methodChannel.invokeMethod('setZoomFactor', zoomFactor);
   }
 
-  /// Sets the [WebviewPopupWindowPolicy].
-  Future<void> setPopupWindowPolicy(
-      WebviewPopupWindowPolicy popupPolicy) async {
-    if (_isDisposed) {
-      return;
-    }
-    assert(value.isInitialized);
-    return _methodChannel.invokeMethod(
-        'setPopupWindowPolicy', popupPolicy.index);
-  }
-
   /// Suspends the web view.
   Future<void> suspend() async {
     if (_isDisposed) {

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -51,6 +51,26 @@ struct WebviewDownloadEvent {
   INT64 totalBytesToReceive;
 };
 
+struct WebviewWindowFeatures {
+  UINT32 height;
+  UINT32 width;
+  BOOL hasPosition;
+  BOOL hasSize;
+  UINT32 left;
+  UINT32 top;
+  BOOL shouldDisplayMenuBar;
+  BOOL shouldDisplayStatus;
+  BOOL shouldDisplayToolbar;
+  BOOL shouldDisplayScrollBars;
+};
+
+struct WebviewNewWindowRequestedArgs {
+  std::string uri;
+  BOOL is_user_initiated;
+  // std::string name;
+  WebviewWindowFeatures window_features;
+};
+
 struct VirtualKeyState {
  public:
   inline void set_isLeftButtonDown(bool is_down) {
@@ -133,7 +153,7 @@ class Webview {
       PermissionRequestedCallback;
   typedef std::function<void(WebviewPopupWindowPolicy policy)> 
       WebviewNewWindowRequestedCompleter;
-  typedef std::function<void(const std::string& url, WebviewNewWindowRequestedCompleter completer)> NewWindowRequestedCallback;
+  typedef std::function<void(const WebviewNewWindowRequestedArgs& args, WebviewNewWindowRequestedCompleter completer)> NewWindowRequestedCallback;
   typedef std::function<void(bool contains_fullscreen_element)>
       ContainsFullScreenElementChangedCallback;
   typedef std::function<void(WebviewDownloadEvent)> DownloadEventCallback;

--- a/windows/webview.h
+++ b/windows/webview.h
@@ -131,6 +131,9 @@ class Webview {
                              bool is_user_initiated,
                              WebviewPermissionRequestedCompleter completer)>
       PermissionRequestedCallback;
+  typedef std::function<void(WebviewPopupWindowPolicy policy)> 
+      WebviewNewWindowRequestedCompleter;
+  typedef std::function<void(const std::string& url, WebviewNewWindowRequestedCompleter completer)> NewWindowRequestedCallback;
   typedef std::function<void(bool contains_fullscreen_element)>
       ContainsFullScreenElementChangedCallback;
   typedef std::function<void(WebviewDownloadEvent)> DownloadEventCallback;
@@ -165,7 +168,6 @@ class Webview {
   bool ClearCookies();
   bool ClearCache();
   bool SetCacheDisabled(bool disabled);
-  void SetPopupWindowPolicy(WebviewPopupWindowPolicy policy);
   bool SetUserAgent(const std::string& user_agent);
   bool OpenDevTools();
   bool SetBackgroundColor(int32_t color);
@@ -224,6 +226,10 @@ class Webview {
     permission_requested_callback_ = std::move(callback);
   }
 
+  void OnNewWindowRequested(NewWindowRequestedCallback callback) {
+    new_window_requested_callback_ = std::move(callback);
+  }
+
   void OnDevtoolsProtocolEvent(DevtoolsProtocolEventCallback callback) {
     devtools_protocol_event_callback_ = std::move(callback);
   }
@@ -246,8 +252,6 @@ class Webview {
   wil::com_ptr<ICoreWebView2Settings2> settings2_;
   POINT last_cursor_pos_ = {0, 0};
   VirtualKeyState virtual_keys_;
-  WebviewPopupWindowPolicy popup_window_policy_ =
-      WebviewPopupWindowPolicy::Allow;
 
   winrt::com_ptr<ABI::Windows::UI::Composition::IVisual> surface_;
   winrt::com_ptr<ABI::Windows::UI::Composition::Desktop::IDesktopWindowTarget>
@@ -267,6 +271,7 @@ class Webview {
   FocusChangedCallback focus_changed_callback_;
   WebMessageReceivedCallback web_message_received_callback_;
   PermissionRequestedCallback permission_requested_callback_;
+  NewWindowRequestedCallback new_window_requested_callback_;
   DevtoolsProtocolEventCallback devtools_protocol_event_callback_;
   ContainsFullScreenElementChangedCallback
       contains_fullscreen_element_changed_callback_;

--- a/windows/webview_bridge.cc
+++ b/windows/webview_bridge.cc
@@ -313,8 +313,8 @@ void WebviewBridge::RegisterEventHandlers() {
       });
 
   webview_->OnNewWindowRequested(
-    [this](const std::string& url, Webview::WebviewNewWindowRequestedCompleter completer) {
-      OnNewWindowRequested(url, completer);
+    [this](const WebviewNewWindowRequestedArgs& args, Webview::WebviewNewWindowRequestedCompleter completer) {
+      OnNewWindowRequested(args, completer);
     }
   );
 
@@ -359,14 +359,28 @@ void WebviewBridge::OnPermissionRequested(
 }
 
 void WebviewBridge::OnNewWindowRequested(
-    const std::string& url, 
+    const WebviewNewWindowRequestedArgs& args, 
     Webview::WebviewNewWindowRequestedCompleter completer) {
-  auto args = std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{
-    {"url", url},
+  auto encodable_args = std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{
+    {"uri", args.uri},
+    {"isUserInitiated", static_cast<bool>(args.is_user_initiated)},
+    // {"name", args.name},
+    {"windowFeatures", flutter::EncodableMap{
+      {"height", static_cast<int32_t>(args.window_features.height)},
+      {"width", static_cast<int32_t>(args.window_features.width)},
+      {"hasPosition", static_cast<bool>(args.window_features.hasPosition)},
+      {"hasSize", static_cast<bool>(args.window_features.hasSize)},
+      {"left", static_cast<int32_t>(args.window_features.left)},
+      {"top", static_cast<int32_t>(args.window_features.top)},
+      {"shouldDisplayMenuBar", static_cast<bool>(args.window_features.shouldDisplayMenuBar)},
+      {"shouldDisplayStatus", static_cast<bool>(args.window_features.shouldDisplayStatus)},
+      {"shouldDisplayToolbar", static_cast<bool>(args.window_features.shouldDisplayToolbar)},
+      {"shouldDisplayScrollBars", static_cast<bool>(args.window_features.shouldDisplayScrollBars)},
+    }},
   });
   
   method_channel_->InvokeMethod(
-    "newWindowRequested", std::move(args),
+    "newWindowRequested", std::move(encodable_args),
     std::make_unique<flutter::MethodResultFunctions<flutter::EncodableValue>>(
       [completer](const flutter::EncodableValue* result) {
         auto policy = std::get_if<int>(result);

--- a/windows/webview_bridge.h
+++ b/windows/webview_bridge.h
@@ -52,4 +52,6 @@ class WebviewBridge {
       const std::string& url, WebviewPermissionKind permissionKind,
       bool is_user_initiated,
       Webview::WebviewPermissionRequestedCompleter completer);
+
+  void OnNewWindowRequested(const std::string& url, Webview::WebviewNewWindowRequestedCompleter completer);
 };

--- a/windows/webview_bridge.h
+++ b/windows/webview_bridge.h
@@ -53,5 +53,5 @@ class WebviewBridge {
       bool is_user_initiated,
       Webview::WebviewPermissionRequestedCompleter completer);
 
-  void OnNewWindowRequested(const std::string& url, Webview::WebviewNewWindowRequestedCompleter completer);
+  void OnNewWindowRequested(const WebviewNewWindowRequestedArgs& args, Webview::WebviewNewWindowRequestedCompleter completer);
 };


### PR DESCRIPTION
The original setPopupWindowPolicy only allowed one policy, while the newWindowRequested can be used to set policies more freely.